### PR TITLE
Do not delete shortlived downtimes

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -64,5 +64,7 @@ commitMessages:
   commitAuthorName: "botovance"
   commitAuthorEmail: "bot@autovance.com"
 
+skipDeleteIssues: true
+
 # Upptime also supports notifications, assigning issues, and more
 # See https://upptime.js.org/docs/configuration


### PR DESCRIPTION
By default upptime would delete downtime issues if they are resolved within 15 minutes. This is not the behaviour we would want, so we're disabling it.
